### PR TITLE
Add manage_all_configs parameter to remove old configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ class { 'ngrok':
 }
 ```
 
+## Get rid of old configuration files if ngrok is already installed
+
+If ngrok is already installed, older configuration files may be defined at /home/username/.ngrok2/ngrok.yml. You can use $manage_all_configs to remove these old configurations as they may apply prior to any configuration set by Puppet (the default is false and will leave these files intact).
+
+```puppet
+class { 'ngrok':
+  manage_all_configs => true,
+}
+```
+
 ## Start ngrok, but don't start tunnels
 
 You might want to define a bunch of tunnels, and have ngrok running, but not have it automatically start any of those tunnels.  Use the `service_tunnels` parameter to instruct ngrok to not automatically enable any tunnels.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,7 @@ class ngrok (
   if ( $manage_all_configs ) {
     tidy { 'old ngrok configs':
       path    => '/home',
-      matches => [ 'ngrok.yml', 'ngrok.yaml'],
+      matches => 'ngrok.yml',
       recurse => true,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,9 @@ class ngrok (
 
   # Parameter to manage unzip which is required by the archive resource.
   Boolean $manage_unzip                     = false,
+
+  # Parameter to manage existing configuration files, as these may interfere with this module
+  Boolean $manage_all_configs               = false,
 ) {
 
   # Let's make sure ..
@@ -42,6 +45,15 @@ class ngrok (
     package { 'unzip':
       ensure => installed,
       before => Archive['/tmp/ngrok.zip'],
+    }
+  }
+
+  # Remove existing ngrok configurations if they exist
+  if ( $manage_all_configs ) {
+    tidy { 'old ngrok configs':
+      path    => '/home',
+      matches => [ 'ngrok.yml', 'ngrok.yaml'],
+      recurse => true,
     }
   }
 


### PR DESCRIPTION
If you install and/or run ngrok manually prior to Puppet management, it will create /home/username/.ngrok2/ngrok.yml for any user that runs it. 

ngrok will process these configurations first, prior to any configuration in /etc/ngrok.yml. Doesn't seem to always happen but happens more often than not.

This PR employs a recursive tidy resource to remove any ngrok.yml files found in /home, triggered by specifying $manage_all_configs => true. The readme has also been updated to reflect this with an example.

The default is $manage_all_configs => false so that we are non-destructive in our management.